### PR TITLE
Write Z as custom attribute while exporting lines to an SVG file

### DIFF
--- a/saga-gis/src/tools/io/io_shapes/svg.cpp
+++ b/saga-gis/src/tools/io/io_shapes/svg.cpp
@@ -269,6 +269,7 @@ void CSVG_Export::Add_Line(CSG_MetaData &SVG, CSG_Shape *pShape, int iPart, long
 		pSVG->Add_Property(SG_T("fill")			, SG_T("none"));
 		pSVG->Add_Property(SG_T("stroke")		, CSG_String::Format(SG_T("rgb(%d,%d,%d)"), SG_GET_R(Color), SG_GET_G(Color), SG_GET_B(Color)));
 		pSVG->Add_Property(SG_T("stroke-width")	, Size);
+		pSVG->Add_Property(SG_T("data-z")		, CSG_String::Format(SG_T("%f"), pShape->Get_Z(0)));
 	}
 }
 


### PR DESCRIPTION
Hello,

I needed to export contour lines in order to import them into another tool (Sketchup).
The elevation in not present in the SVG file and changing the line color doesn't help as the color exported to the SVG is hardcoded.
I added a custom attribute (data-z) that contains the Z value for lines exported to SVG.

This change is very helpful to me and doesn't impact the existing attributes.

Thanks for the great tool!