### PR TITLE
saga_api, parameter description: output data object type for generic "DataObject_Output" to XML definition

### DIFF
--- a/saga-gis/src/saga_core/saga_api/tool.cpp
+++ b/saga-gis/src/saga_core/saga_api/tool.cpp
@@ -1162,7 +1162,17 @@ void _Add_XML(CSG_MetaData *pParent, CSG_Parameter *pParameter, CSG_String ID = 
 	pItem->Add_Property(SG_XML_PARAM_ATT_CLASS,	pParameter->is_Input() ? "input" : pParameter->is_Output() ? "output" : "option");
 
 	pItem->Add_Child(SG_XML_PARAM_IDENT, ID);
-	pItem->Add_Child(SG_XML_PARAM_TYPE , pParameter->Get_Type_Name().Make_Lower());
+
+	if( pParameter->Get_Type() == PARAMETER_TYPE_DataObject_Output )
+	{
+		CSG_String typeName = CSG_String::Format("%s %s", pParameter->Get_Type_Name().Make_Lower().c_str(), SG_Get_DataObject_Name(pParameter->Get_DataObject_Type()).Make_Lower().c_str());
+	    pItem->Add_Child(SG_XML_PARAM_TYPE , typeName);
+    }
+    else
+    {
+	    pItem->Add_Child(SG_XML_PARAM_TYPE , pParameter->Get_Type_Name().Make_Lower());
+    }
+
 	pItem->Add_Child(SG_XML_PARAM_MAND , pParameter->is_Optional() ? SG_T("false") : SG_T("true"));
 	pItem->Add_Child(SG_XML_DESCRIPTION, pParameter->Get_Description());
 


### PR DESCRIPTION
Adds "data object" subtype to the SAGA module definition in XML format. Similarly to the how it works for plain text description https://sourceforge.net/p/saga-gis/code/ci/bbbb7ee62a7eca9d904d512b111cc3169c90ec5a/