### PR TITLE
aga_api: produce valid xml when printing modules list

### DIFF
--- a/saga-gis/src/saga_core/saga_api/tool_library.cpp
+++ b/saga-gis/src/saga_core/saga_api/tool_library.cpp
@@ -249,7 +249,7 @@ CSG_String CSG_Tool_Library::Get_Summary(int Format, bool bWithGUINeeded) const
 		{
 			if( Get_Tool(i) && (bWithGUINeeded || !Get_Tool(i)->needs_GUI()) )
 			{
-				s	+= CSG_String::Format("\t<%s %s=\"%s\" %s=\"%s\">\n", SG_XML_TOOL,
+				s	+= CSG_String::Format("\t<%s %s=\"%s\" %s=\"%s\"/>\n", SG_XML_TOOL,
 					SG_XML_TOOL_ATT_ID  , Get_Tool(i)->Get_ID  ().c_str(),
 					SG_XML_TOOL_ATT_NAME, Get_Tool(i)->Get_Name().c_str()
 				);


### PR DESCRIPTION
I can be wrong, but seems that `saga_cmd` produces invalid XML output when printing list of library tools. Instead of
```
<module id="0" name="Grid Normalisation">
```
we should have
```
<module id="0" name="Grid Normalisation"/>
```